### PR TITLE
Fix test compile target and script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,7 @@ debug: build-all
 build-all: setup-cmake
 	make -C $(BUILD_DIR)
 
-test: CMAKE_BUILD_TYPE=Debug
-test: BUILD_DIR=$(BUILD)/debug
-test: setup-cmake
-	make -C$(BUILD_DIR) lcfit-shared
+test: debug
 	python test/test_lcfit.py -v
 
 example: release lcfit-compare

--- a/test/test_lcfit.py
+++ b/test/test_lcfit.py
@@ -4,7 +4,7 @@ from ctypes import c_double, c_ulong, POINTER, byref, Structure, cdll, \
 import math
 import unittest
 
-liblcfit = cdll.LoadLibrary("_build/debug/lcfit_src/liblcfit-shared.so")
+liblcfit = cdll.LoadLibrary("_build/debug/lcfit_src/liblcfit.so")
 
 
 # Definitions


### PR DESCRIPTION
The lcfit-shared target no longer appears to exist, and I updated the soname in the test script to reflect that as well.
